### PR TITLE
Feat/salespost

### DIFF
--- a/src/components/salespost/CategoryInput.jsx
+++ b/src/components/salespost/CategoryInput.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { InputBox } from 'pages/Salespost';
+
+const Category = ({ register }) => {
+	return (
+		<InputBox>
+			<label>카테고리</label>
+			<select {...register('category', { required: true })}>
+				<option value="flower">꽃</option>
+				<option value="foliage">관엽/공기정화</option>
+				<option value="succulence">다육식물</option>
+				<option value="wild">야생화/분재</option>
+				<option value="orchid">동/서양란</option>
+				<option value="seed">묘목/씨앗</option>
+				<option value="else">기타</option>
+			</select>
+		</InputBox>
+	);
+};
+
+export default Category;

--- a/src/components/salespost/DeliveryInput.jsx
+++ b/src/components/salespost/DeliveryInput.jsx
@@ -1,8 +1,8 @@
 import React, { useState } from 'react';
-import { InputBox, RadioBtn } from 'pages/Salespost';
+import { InputBox, RadioBtn, ErrorMsg } from 'pages/Salespost';
 import AddressSelector from './AddressInput';
 
-export const Delivery = ({ register, setValue }) => {
+export const Delivery = ({ register, errors, setValue }) => {
 	const [showAddress, setShowAddress] = useState(false);
 
 	return (
@@ -27,6 +27,9 @@ export const Delivery = ({ register, setValue }) => {
 					</label>
 				</RadioBtn>
 			</InputBox>
+			{errors.deliver_type !== undefined && (
+				<ErrorMsg style={{ paddingLeft: '6rem' }}>{errors.deliver_type.message}</ErrorMsg>
+			)}
 			{showAddress ? <AddressSelector register={register} setValue={setValue} /> : null}
 		</>
 	);

--- a/src/components/salespost/DeliveryInput.jsx
+++ b/src/components/salespost/DeliveryInput.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
-import { InputBox, RadioBtn, ErrorMsg } from 'pages/Salespost';
+import { InputBox, RadioBtn } from 'pages/Salespost';
 import AddressSelector from './AddressInput';
+import ErrorMsg from './ErrorMessage';
 
 export const Delivery = ({ register, errors, setValue }) => {
 	const [showAddress, setShowAddress] = useState(false);
@@ -28,7 +29,7 @@ export const Delivery = ({ register, errors, setValue }) => {
 				</RadioBtn>
 			</InputBox>
 			{errors.deliver_type !== undefined && (
-				<ErrorMsg style={{ paddingLeft: '6rem' }}>{errors.deliver_type.message}</ErrorMsg>
+				<ErrorMsg paddingLeft="6.2rem">{errors.deliver_type.message}</ErrorMsg>
 			)}
 			{showAddress ? <AddressSelector register={register} setValue={setValue} /> : null}
 		</>

--- a/src/components/salespost/DeliveryInput.jsx
+++ b/src/components/salespost/DeliveryInput.jsx
@@ -1,0 +1,33 @@
+import React, { useState } from 'react';
+import { InputBox, RadioBtn } from 'pages/Salespost';
+import AddressSelector from './AddressInput';
+
+export const Delivery = ({ register, setValue }) => {
+	const [showAddress, setShowAddress] = useState(false);
+
+	return (
+		<>
+			<InputBox style={{ marginBottom: 0 }}>
+				<label>배송 방법</label>
+				<RadioBtn>
+					<input type="radio" id="delivery" {...register('deliver_type')} value="courier" />
+					<label htmlFor="delivery" onClick={() => setShowAddress(false)}>
+						택배
+					</label>
+				</RadioBtn>
+				<RadioBtn>
+					<input
+						type="radio"
+						id="meet"
+						{...register('deliver_type', { required: '필수 입력 값입니다.' })}
+						value="direct"
+					/>
+					<label htmlFor="meet" onClick={() => setShowAddress(true)}>
+						직거래
+					</label>
+				</RadioBtn>
+			</InputBox>
+			{showAddress ? <AddressSelector register={register} setValue={setValue} /> : null}
+		</>
+	);
+};

--- a/src/components/salespost/DescriptionInput.jsx
+++ b/src/components/salespost/DescriptionInput.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { InputBox } from 'pages/Salespost';
+import { Editor } from '@tinymce/tinymce-react';
+
+const Description = ({ API_KEY, editorRef }) => {
+	return (
+		<InputBox>
+			<label>상세 설명</label>
+			<Editor
+				apiKey={API_KEY}
+				// ref={editorRef}
+				onInit={(evt, editor) => (editorRef.current = editor)}
+				initialValue=""
+				init={{
+					height: 500,
+					menubar: false,
+					plugins: [
+						'advlist',
+						'autolink',
+						'lists',
+						'link',
+						'image',
+						'charmap',
+						'preview',
+						'anchor',
+						'searchreplace',
+						'visualblocks',
+						'code',
+						'fullscreen',
+						'insertdatetime',
+						'media',
+						'table',
+						'code',
+						'help',
+						'wordcount',
+					],
+					toolbar:
+						'undo redo | blocks | ' +
+						'bold italic forecolor | alignleft aligncenter ' +
+						'alignright alignjustify | bullist numlist outdent indent | ' +
+						'removeformat | help',
+					content_style: 'body { font-family:Helvetica,Arial,sans-serif; font-size:14px }',
+				}}
+			/>
+		</InputBox>
+	);
+};
+
+export default Description;

--- a/src/components/salespost/ErrorMessage.jsx
+++ b/src/components/salespost/ErrorMessage.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const ErrorBox = styled.span`
+	font-size: 12.5px;
+	color: red;
+	padding-top: 0.5rem;
+	padding-left: ${props => props.paddingLeft || '0.1rem'};
+	//margin-bottom: 12px;
+`;
+
+const ErrorMsg = ({ paddingLeft, children }) => {
+	return <ErrorBox paddingLeft={paddingLeft}>⚠ {children}</ErrorBox>;
+};
+
+export default ErrorMsg;

--- a/src/components/salespost/ImageInput.jsx
+++ b/src/components/salespost/ImageInput.jsx
@@ -132,6 +132,10 @@ const ImageInput = ({ register }) => {
 	const onDelete = id => {
 		setImgFiles(prev => {
 			const copied = [...prev];
+			// 삭제할 이미지가 유일한 이미지이면
+			if (copied.length === 1) {
+				return [];
+			}
 			const tempList = copied.filter(file => file.id !== id);
 			if (copied[0].id === id) {
 				// 삭제한 이미지가 대표사진이면

--- a/src/components/salespost/ImageInput.jsx
+++ b/src/components/salespost/ImageInput.jsx
@@ -3,6 +3,7 @@ import { useRecoilState } from 'recoil';
 import { imageFiles } from './atoms';
 import styled from 'styled-components';
 import { COLOR } from 'constants/color';
+import { InputBox } from 'pages/Salespost';
 
 export const ImageWrapper = styled.div`
 	min-width: 485px;
@@ -86,18 +87,6 @@ export const Image = styled.div`
 		visibility: visible;
 		background-color: #2bb601;
 	}
-`;
-
-export const InputBox = styled.div`
-	display: flex;
-	flex-direction: column;
-	justify-content: center;
-	align-items: flex-start;
-	min-width: 270px;
-	margin: 10px;
-	border-radius: 5px;
-	background-color: white;
-	padding: 10px;
 `;
 
 const ImageInput = ({ register }) => {

--- a/src/components/salespost/MainInfoInput.jsx
+++ b/src/components/salespost/MainInfoInput.jsx
@@ -1,45 +1,80 @@
 import React from 'react';
-import { InputBox } from 'pages/Salespost';
+import { InputBox, ErrorMsg } from 'pages/Salespost';
 
-export const PostTitle = ({ register }) => {
+export const PostTitle = ({ register, errors }) => {
 	return (
-		<InputBox>
-			<label>제목</label>
-			<input {...register('feed_Stock', { required: '필수 입력 값입니다.' })} type="text" />
-		</InputBox>
+		<>
+			<InputBox>
+				<label>제목</label>
+				<input
+					{...register('feed_Stock', {
+						required: '필수 입력 값입니다.',
+						maxLength: {
+							value: 20,
+							message: '최대 20자까지 입력 가능합니다.',
+						},
+					})}
+					type="text"
+				/>
+			</InputBox>
+			{errors.feed_Stock !== undefined && <ErrorMsg>{errors.feed_Stock.message}</ErrorMsg>}
+		</>
 	);
 };
 
-export const PlantName = ({ register }) => {
+export const PlantName = ({ register, errors }) => {
 	return (
-		<InputBox>
-			<label>상품명</label>
-			<input {...register('plant_type', { required: '필수 입력 값입니다.' })} type="text" />
-		</InputBox>
+		<>
+			<InputBox>
+				<label>상품명</label>
+				<input
+					{...register('plant_type', {
+						required: '필수 입력 값입니다.',
+						pattern: { value: /^[^\s]+$/, message: '띄어쓰기는 불가합니다.' },
+					})}
+					type="text"
+				/>
+			</InputBox>
+			{errors.plant_type !== undefined && <ErrorMsg>{errors.plant_type.message}</ErrorMsg>}
+		</>
 	);
 };
 
-export const PlantPrice = ({ register }) => {
+export const PlantPrice = ({ register, errors }) => {
 	return (
-		<InputBox>
-			<label>판매가</label>
-			<div>
-				<input {...register('price', { required: '필수 입력 값입니다.' })} type="number" min={0} />
-				원
-			</div>
-		</InputBox>
+		<>
+			<InputBox>
+				<label>판매가</label>
+				<div>
+					<input
+						{...register('price', { required: '필수 입력 값입니다.' })}
+						type="number"
+						min={0}
+					/>
+					원
+				</div>
+			</InputBox>
+			{errors.price !== undefined && <ErrorMsg>{errors.price.message}</ErrorMsg>}
+		</>
 	);
 };
 
-export const PlantStock = ({ register }) => {
+export const PlantStock = ({ register, errors }) => {
 	return (
-		<InputBox>
-			<label>재고</label>
-			<div>
-				<input {...register('stock', { required: '필수 입력 값입니다.' })} type="number" min={0} />
-				개
-			</div>
-		</InputBox>
+		<>
+			<InputBox>
+				<label>재고</label>
+				<div>
+					<input
+						{...register('stock', { required: '필수 입력 값입니다.' })}
+						type="number"
+						min={0}
+					/>
+					개
+				</div>
+			</InputBox>
+			{errors.stock !== undefined && <ErrorMsg>{errors.stock.message}</ErrorMsg>}
+		</>
 	);
 };
 

--- a/src/components/salespost/MainInfoInput.jsx
+++ b/src/components/salespost/MainInfoInput.jsx
@@ -1,80 +1,65 @@
 import React from 'react';
-import { InputBox, ErrorMsg } from 'pages/Salespost';
+import { InputBox } from 'pages/Salespost';
+import ErrorMsg from './ErrorMessage';
 
 export const PostTitle = ({ register, errors }) => {
 	return (
-		<>
-			<InputBox>
-				<label>제목</label>
-				<input
-					{...register('feed_Stock', {
-						required: '필수 입력 값입니다.',
-						maxLength: {
-							value: 20,
-							message: '최대 20자까지 입력 가능합니다.',
-						},
-					})}
-					type="text"
-				/>
-			</InputBox>
+		<InputBox>
+			<label>제목</label>
+			<input
+				{...register('feed_Stock', {
+					required: '필수 입력 값입니다.',
+					maxLength: {
+						value: 20,
+						message: '최대 20자까지 입력 가능합니다.',
+					},
+				})}
+				type="text"
+			/>
 			{errors.feed_Stock !== undefined && <ErrorMsg>{errors.feed_Stock.message}</ErrorMsg>}
-		</>
+		</InputBox>
 	);
 };
 
 export const PlantName = ({ register, errors }) => {
 	return (
-		<>
-			<InputBox>
-				<label>상품명</label>
-				<input
-					{...register('plant_type', {
-						required: '필수 입력 값입니다.',
-						pattern: { value: /^[^\s]+$/, message: '띄어쓰기는 불가합니다.' },
-					})}
-					type="text"
-				/>
-			</InputBox>
+		<InputBox>
+			<label>상품명</label>
+			<input
+				{...register('plant_type', {
+					required: '필수 입력 값입니다.',
+					pattern: { value: /^[^\s]+$/, message: '띄어쓰기는 불가합니다.' },
+				})}
+				type="text"
+			/>
 			{errors.plant_type !== undefined && <ErrorMsg>{errors.plant_type.message}</ErrorMsg>}
-		</>
+		</InputBox>
 	);
 };
 
 export const PlantPrice = ({ register, errors }) => {
 	return (
-		<>
-			<InputBox>
-				<label>판매가</label>
-				<div>
-					<input
-						{...register('price', { required: '필수 입력 값입니다.' })}
-						type="number"
-						min={0}
-					/>
-					원
-				</div>
-			</InputBox>
+		<InputBox>
+			<label>판매가</label>
+			<div>
+				<input {...register('price', { required: '필수 입력 값입니다.' })} type="number" min={0} />
+				원
+			</div>
 			{errors.price !== undefined && <ErrorMsg>{errors.price.message}</ErrorMsg>}
-		</>
+		</InputBox>
 	);
 };
 
 export const PlantStock = ({ register, errors }) => {
 	return (
-		<>
-			<InputBox>
-				<label>재고</label>
-				<div>
-					<input
-						{...register('stock', { required: '필수 입력 값입니다.' })}
-						type="number"
-						min={0}
-					/>
-					개
-				</div>
-			</InputBox>
+		<InputBox>
+			<label>재고</label>
+			<div>
+				<input {...register('stock', { required: '필수 입력 값입니다.' })} type="number" min={0} />
+				개
+			</div>
 			{errors.stock !== undefined && <ErrorMsg>{errors.stock.message}</ErrorMsg>}
-		</>
+		</InputBox>
 	);
 };
 

--- a/src/components/salespost/MainInfoInput.jsx
+++ b/src/components/salespost/MainInfoInput.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { InputBox } from 'pages/Salespost';
+
+export const PostTitle = ({ register }) => {
+	return (
+		<InputBox>
+			<label>제목</label>
+			<input {...register('feed_Stock', { required: '필수 입력 값입니다.' })} type="text" />
+		</InputBox>
+	);
+};
+
+export const PlantName = ({ register }) => {
+	return (
+		<InputBox>
+			<label>상품명</label>
+			<input {...register('plant_type', { required: '필수 입력 값입니다.' })} type="text" />
+		</InputBox>
+	);
+};
+
+export const PlantPrice = ({ register }) => {
+	return (
+		<InputBox>
+			<label>판매가</label>
+			<div>
+				<input {...register('price', { required: '필수 입력 값입니다.' })} type="number" min={0} />
+				원
+			</div>
+		</InputBox>
+	);
+};
+
+export const PlantStock = ({ register }) => {
+	return (
+		<InputBox>
+			<label>재고</label>
+			<div>
+				<input {...register('stock', { required: '필수 입력 값입니다.' })} type="number" min={0} />
+				개
+			</div>
+		</InputBox>
+	);
+};
+
+export const Pot = ({ register }) => {
+	return (
+		<InputBox>
+			<label>화분 종류</label>
+			<input {...register('pot_type')} type="text" />
+		</InputBox>
+	);
+};

--- a/src/components/salespost/OriginInput.jsx
+++ b/src/components/salespost/OriginInput.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { InputBox, RadioBtn } from 'pages/Salespost';
+
+export const Origin = ({ register }) => {
+	return (
+		<InputBox style={{ marginBottom: 0 }}>
+			<label>원산지</label>
+			<RadioBtn>
+				<input type="radio" id="native" {...register('origin')} value="domestic" />
+				<label htmlFor="native">국산</label>
+			</RadioBtn>
+			<RadioBtn>
+				<input type="radio" id="abroad" {...register('origin')} value="import" />
+				<label htmlFor="abroad">수입산</label>
+			</RadioBtn>
+			<RadioBtn>
+				<input
+					type="radio"
+					id="else"
+					{...register('origin', { required: '필수 입력 값입니다.' })}
+					value="else"
+				/>
+				<label htmlFor="else">모름</label>
+			</RadioBtn>
+		</InputBox>
+	);
+};

--- a/src/components/salespost/OriginInput.jsx
+++ b/src/components/salespost/OriginInput.jsx
@@ -1,27 +1,32 @@
 import React from 'react';
-import { InputBox, RadioBtn } from 'pages/Salespost';
+import { InputBox, RadioBtn, ErrorMsg } from 'pages/Salespost';
 
-export const Origin = ({ register }) => {
+export const Origin = ({ register, errors }) => {
 	return (
-		<InputBox style={{ marginBottom: 0 }}>
-			<label>원산지</label>
-			<RadioBtn>
-				<input type="radio" id="native" {...register('origin')} value="domestic" />
-				<label htmlFor="native">국산</label>
-			</RadioBtn>
-			<RadioBtn>
-				<input type="radio" id="abroad" {...register('origin')} value="import" />
-				<label htmlFor="abroad">수입산</label>
-			</RadioBtn>
-			<RadioBtn>
-				<input
-					type="radio"
-					id="else"
-					{...register('origin', { required: '필수 입력 값입니다.' })}
-					value="else"
-				/>
-				<label htmlFor="else">모름</label>
-			</RadioBtn>
-		</InputBox>
+		<>
+			<InputBox style={{ marginBottom: 0 }}>
+				<label>원산지</label>
+				<RadioBtn>
+					<input type="radio" id="native" {...register('origin')} value="domestic" />
+					<label htmlFor="native">국산</label>
+				</RadioBtn>
+				<RadioBtn>
+					<input type="radio" id="abroad" {...register('origin')} value="import" />
+					<label htmlFor="abroad">수입산</label>
+				</RadioBtn>
+				<RadioBtn>
+					<input
+						type="radio"
+						id="else"
+						{...register('origin', { required: '필수 입력 값입니다.' })}
+						value="else"
+					/>
+					<label htmlFor="else">모름</label>
+				</RadioBtn>
+			</InputBox>
+			{errors.origin !== undefined && (
+				<ErrorMsg style={{ paddingLeft: '6rem' }}>{errors.origin.message}</ErrorMsg>
+			)}
+		</>
 	);
 };

--- a/src/components/salespost/OriginInput.jsx
+++ b/src/components/salespost/OriginInput.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { InputBox, RadioBtn, ErrorMsg } from 'pages/Salespost';
+import { InputBox, RadioBtn } from 'pages/Salespost';
+import ErrorMsg from './ErrorMessage';
 
 export const Origin = ({ register, errors }) => {
 	return (
@@ -25,7 +26,7 @@ export const Origin = ({ register, errors }) => {
 				</RadioBtn>
 			</InputBox>
 			{errors.origin !== undefined && (
-				<ErrorMsg style={{ paddingLeft: '6rem' }}>{errors.origin.message}</ErrorMsg>
+				<ErrorMsg paddingLeft="6.2rem">{errors.origin.message}</ErrorMsg>
 			)}
 		</>
 	);

--- a/src/components/salespost/SizeInput.jsx
+++ b/src/components/salespost/SizeInput.jsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { InputBox } from 'pages/Salespost';
+import styled from 'styled-components';
+
+export const SizeInputWrapper = styled.div`
+	display: flex;
+	div {
+		display: inherit;
+		flex-direction: column;
+	}
+`;
+
+export const SizeInput = styled.div`
+	height: 24px;
+	min-width: 100px;
+	position: relative;
+	padding-left: 40px;
+	margin-bottom: 7px;
+	& {
+		border: 1px solid rgba(0, 0, 0, 0.5);
+	}
+	span {
+		font-size: 14px;
+		text-align: center;
+		position: absolute;
+		left: 3px;
+		top: 4px;
+	}
+	input {
+		font-size: 15px;
+		min-width: 160px;
+		height: 100%;
+		border: none;
+	}
+`;
+
+export const Size = ({ register }) => {
+	return (
+		<InputBox>
+			<SizeInputWrapper>
+				<label>사이즈(cm)</label>
+				<div>
+					<SizeInput>
+						<span>가로 |</span>
+						<input style={{ border: 'none' }} {...register('plant_width')} type="number" min={0} />
+					</SizeInput>
+					<SizeInput>
+						<span>세로 |</span>
+						<input
+							style={{ border: 'none' }}
+							{...register('plant_vertical')}
+							type="number"
+							min={0}
+						/>
+					</SizeInput>
+					<SizeInput>
+						<span>높이 |</span>
+						<input style={{ border: 'none' }} {...register('plant_height')} type="number" min={0} />
+					</SizeInput>
+				</div>
+			</SizeInputWrapper>
+		</InputBox>
+	);
+};

--- a/src/pages/Salespost.jsx
+++ b/src/pages/Salespost.jsx
@@ -173,7 +173,7 @@ const Salespost = () => {
 		register,
 		handleSubmit,
 		setValue,
-		formState: { errors },
+		formState: { errors, isSubmitting },
 	} = useForm();
 	const onValid = data => {
 		// const newObj = []...imgFiles],
@@ -247,7 +247,7 @@ const Salespost = () => {
 				</Form>
 			</Container>
 			<BtnBox>
-				<Button type="submit" form="hook-form">
+				<Button type="submit" form="hook-form" disabled={isSubmitting}>
 					판매글 등록하기
 				</Button>
 			</BtnBox>

--- a/src/pages/Salespost.jsx
+++ b/src/pages/Salespost.jsx
@@ -146,13 +146,6 @@ export const Button = styled.button`
 	}
 `;
 
-export const ErrorMsg = styled.span`
-	font-size: 12px;
-	color: red;
-	padding-left: 1.5rem;
-	margin-bottom: 10px;
-`;
-
 const Salespost = () => {
 	const API_KEY = 'hu8nfu3m325us5grhquqzn0vsvf8stfwc214ef8x70fwvc7z';
 	const navigate = useNavigate();

--- a/src/pages/Salespost.jsx
+++ b/src/pages/Salespost.jsx
@@ -1,11 +1,23 @@
-import React, { useRef, useState } from 'react';
+import React, { useRef } from 'react';
 import { useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
-import AddressSelector from 'components/Salespost/AddressInput';
+
+import Category from 'components/Salespost/CategoryInput';
+import {
+	PostTitle,
+	PlantName,
+	PlantPrice,
+	PlantStock,
+	Pot,
+} from 'components/Salespost/MainInfoInput';
 import { imageFiles } from 'components/Salespost/atoms';
 import ImageInput from 'components/Salespost/ImageInput';
-import { Editor } from '@tinymce/tinymce-react';
+import { Origin } from 'components/Salespost/OriginInput';
+import { Size } from 'components/Salespost/SizeInput';
+import { Delivery } from 'components/Salespost/DeliveryInput';
+import Description from 'components/Salespost/DescriptionInput';
+
 import axios from 'axios';
 import styled from 'styled-components';
 import { COLOR } from 'constants/color';
@@ -88,7 +100,7 @@ export const InputDetailWrapper = styled.div`
 		flex-direction: row;
 		justify-content: flex-start;
 		align-items: center;
-		margin-bottom: 20px;
+		margin-top: 20px;
 	}
 	label {
 		font-size: 12px;
@@ -118,36 +130,6 @@ export const RadioBtn = styled.div`
 	}
 `;
 
-export const SizeInputWrapper = styled.div`
-	display: flex;
-	div {
-		display: inherit;
-		flex-direction: column;
-	}
-`;
-
-export const SizeInput = styled.div`
-	border: 1px solid rgba(0, 0, 0, 0.5);
-	height: 24px;
-	min-width: 100px;
-	position: relative;
-	padding-left: 40px;
-	margin-bottom: 7px;
-	span {
-		font-size: 14px;
-		text-align: center;
-		position: absolute;
-		left: 3px;
-		top: 4px;
-	}
-	input {
-		font-size: 15px;
-		min-width: 160px;
-		height: 100%;
-		border: none;
-	}
-`;
-
 export const BtnBox = styled.div`
 	text-align: center;
 `;
@@ -167,7 +149,6 @@ export const Button = styled.button`
 const Salespost = () => {
 	const API_KEY = 'hu8nfu3m325us5grhquqzn0vsvf8stfwc214ef8x70fwvc7z';
 	const navigate = useNavigate();
-	const [showAddress, setShowAddress] = useState(false);
 	const imgFiles = useRecoilValue(imageFiles);
 
 	const postData = async input => {
@@ -230,156 +211,25 @@ const Salespost = () => {
 	return (
 		<Wrapper>
 			<Container>
-				<Title>상품 등록</Title>
+				<Title>판매글 등록하기</Title>
 				<Form onSubmit={handleSubmit(onValid, inValid)} id="hook-form">
 					<InputWrapper>
-						<InputBox>
-							<label>카테고리</label>
-							<select {...register('category', { required: true })}>
-								<option value="flower">꽃</option>
-								<option value="foliage">관엽/공기정화</option>
-								<option value="succulence">다육식물</option>
-								<option value="wild">야생화/분재</option>
-								<option value="orchid">동/서양란</option>
-								<option value="seed">묘목/씨앗</option>
-								<option value="else">기타</option>
-							</select>
-						</InputBox>
-						<InputBox>
-							<label>제목</label>
-							<input {...register('feed_title', { required: true })} type="text" />
-						</InputBox>
-						<InputBox>
-							<label>상품명</label>
-							<input {...register('plant_type', { required: true })} type="text" />
-						</InputBox>
-						<InputBox>
-							<label>판매가</label>
-							<div>
-								<input {...register('price', { required: true })} type="number" min={0} />원
-							</div>
-						</InputBox>
-						<InputBox>
-							<label>재고</label>
-							<div>
-								<input {...register('stock', { required: true })} type="number" min={0} />개
-							</div>
-						</InputBox>
-
+						<Category register={register} />
+						<PostTitle register={register} />
+						<PlantName register={register} />
+						<PlantPrice register={register} />
+						<PlantStock register={register} />
 						<ImageInput register={register} />
 						<InputBox>
 							<label>상품 주요 정보</label>
 							<InputDetailWrapper>
-								<InputBox>
-									<label>원산지</label>
-									<RadioBtn>
-										<input type="radio" id="native" {...register('origin')} value="domestic" />
-										<label htmlFor="native">국산</label>
-									</RadioBtn>
-									<RadioBtn>
-										<input type="radio" id="abroad" {...register('origin')} value="import" />
-										<label htmlFor="abroad">수입산</label>
-									</RadioBtn>
-									<RadioBtn>
-										<input
-											type="radio"
-											id="else"
-											{...register('origin', { required: true })}
-											value="else"
-										/>
-										<label htmlFor="else">모름</label>
-									</RadioBtn>
-								</InputBox>
-								<InputBox>
-									<SizeInputWrapper>
-										<label>사이즈(cm)</label>
-										<div>
-											<SizeInput>
-												<span>가로 |</span>
-												<input {...register('plant_width')} type="number" min={0} />
-											</SizeInput>
-											<SizeInput>
-												<span>세로 |</span>
-												<input {...register('plant_vertical')} type="number" min={0} />
-											</SizeInput>
-											<SizeInput>
-												<span>높이 |</span>
-												<input {...register('plant_height')} type="number" min={0} />
-											</SizeInput>
-										</div>
-									</SizeInputWrapper>
-								</InputBox>
-								<InputBox>
-									<label>화분 종류</label>
-									<input {...register('pot_type')} type="text" />
-								</InputBox>
-								<InputBox>
-									<label>배송 방법</label>
-									<RadioBtn>
-										<input
-											type="radio"
-											id="delivery"
-											{...register('deliver_type', { required: true })}
-											value="courier"
-										/>
-										<label htmlFor="delivery" onClick={() => setShowAddress(false)}>
-											택배
-										</label>
-									</RadioBtn>
-									<RadioBtn>
-										<input
-											type="radio"
-											id="meet"
-											{...register('deliver_type', { required: true })}
-											value="direct"
-										/>
-										<label htmlFor="meet" onClick={() => setShowAddress(true)}>
-											직거래
-										</label>
-									</RadioBtn>
-								</InputBox>
-								{showAddress ? <AddressSelector register={register} setValue={setValue} /> : null}
+								<Origin register={register} />
+								<Size register={register} />
+								<Pot register={register} />
+								<Delivery register={register} setValue={setValue} />
 							</InputDetailWrapper>
 						</InputBox>
-						<InputBox>
-							<label>상세 설명</label>
-							<Editor
-								apiKey={API_KEY}
-								// ref={editorRef}
-								onInit={(evt, editor) => (editorRef.current = editor)}
-								initialValue=""
-								init={{
-									height: 500,
-									menubar: false,
-									plugins: [
-										'advlist',
-										'autolink',
-										'lists',
-										'link',
-										'image',
-										'charmap',
-										'preview',
-										'anchor',
-										'searchreplace',
-										'visualblocks',
-										'code',
-										'fullscreen',
-										'insertdatetime',
-										'media',
-										'table',
-										'code',
-										'help',
-										'wordcount',
-									],
-									toolbar:
-										'undo redo | blocks | ' +
-										'bold italic forecolor | alignleft aligncenter ' +
-										'alignright alignjustify | bullist numlist outdent indent | ' +
-										'removeformat | help',
-									content_style: 'body { font-family:Helvetica,Arial,sans-serif; font-size:14px }',
-								}}
-							/>
-						</InputBox>
+						<Description API_KEY={API_KEY} editorRef={editorRef} />
 					</InputWrapper>
 				</Form>
 			</Container>

--- a/src/pages/Salespost.jsx
+++ b/src/pages/Salespost.jsx
@@ -146,6 +146,13 @@ export const Button = styled.button`
 	}
 `;
 
+export const ErrorMsg = styled.span`
+	font-size: 12px;
+	color: red;
+	padding-left: 1.5rem;
+	margin-bottom: 10px;
+`;
+
 const Salespost = () => {
 	const API_KEY = 'hu8nfu3m325us5grhquqzn0vsvf8stfwc214ef8x70fwvc7z';
 	const navigate = useNavigate();
@@ -162,7 +169,12 @@ const Salespost = () => {
 		}
 	};
 
-	const { register, handleSubmit, setValue } = useForm();
+	const {
+		register,
+		handleSubmit,
+		setValue,
+		formState: { errors },
+	} = useForm();
 	const onValid = data => {
 		// const newObj = []...imgFiles],
 
@@ -203,6 +215,7 @@ const Salespost = () => {
 		postData(parsedData);
 	};
 	const inValid = errors => {
+		alert('입력 조건을 만족시켜주세요!');
 		console.log(errors);
 	};
 
@@ -215,18 +228,18 @@ const Salespost = () => {
 				<Form onSubmit={handleSubmit(onValid, inValid)} id="hook-form">
 					<InputWrapper>
 						<Category register={register} />
-						<PostTitle register={register} />
-						<PlantName register={register} />
-						<PlantPrice register={register} />
-						<PlantStock register={register} />
+						<PostTitle register={register} errors={errors} />
+						<PlantName register={register} errors={errors} />
+						<PlantPrice register={register} errors={errors} />
+						<PlantStock register={register} errors={errors} />
 						<ImageInput register={register} />
 						<InputBox>
 							<label>상품 주요 정보</label>
 							<InputDetailWrapper>
-								<Origin register={register} />
+								<Origin register={register} errors={errors} />
 								<Size register={register} />
 								<Pot register={register} />
-								<Delivery register={register} setValue={setValue} />
+								<Delivery register={register} errors={errors} setValue={setValue} />
 							</InputDetailWrapper>
 						</InputBox>
 						<Description API_KEY={API_KEY} editorRef={editorRef} />


### PR DESCRIPTION
## 작업 내용

- Salespost page 리팩토링 마무리
- input validation 코드 추가, 에러 메시지 컴포넌트 생성
    - 판매글 제목: 필수, 최대 20자
    - 상품 이름: 필수, 띄어쓰기 비허용
    - 가격: 필수
    - 재고: 필수
    - 원산지: 필수
    - 배송 방법: 필수
- 리팩토링 중 이미지 미리보기 리스트에서 마지막 이미지 삭제 안되는 에러 발견해서 해결
- POST 전송 중 submit 버튼 비활성화 기능 추가
    - 표면에 크게 드러나는 차이는 없지만, 등록 버튼 중복 클릭을 막아두는 게 좋을 것 같아서 추가해봤습니다.


## 기타 사항

1. salespost 페이지에 있는 인풋들을 최대한 컴포넌트로 분리해봤는데,
    
    category, origin처럼 길이가 있는 것들은 개별 파일로 분리했고, title, price처럼 짧은 인풋들은 MainInfoInput 파일에 모아서 각각 export하도록 작성해봤습니다. 
    
    지금은 Salespost 페이지에서 각 인풋들을 렌더링 할 때 어느 위치에 어떤 컴포넌트들이 렌더링 되는 지를 컴포넌트 이름으로 보여주는 게 낫다고 생각해서 모든 인풋 코드들을 하나하나 분리해 놓은 상태인데, 여러 인풋들을 큰 컴포넌트로 묶어서 한 번에 렌더링하는 게 더 깔끔해 보이진 않을까 고민이네요.. 혹시 의견 있으시면 공유 부탁드립니다!


2. 에러 메시지 띄우는 위치
    ![Untitled](https://user-images.githubusercontent.com/96769323/202991280-6cde1947-ce3a-4069-b95c-b9bdc759b5a4.png)

    에러 메시지를 출력할 위치를 아직 정확하게 못 정해서 같이 생각해봤으면 좋겠어요!
    
    1안은 맨 위처럼 인풋 라벨 옆이고, 2안은 인풋 아래인데, 지금은 2안으로 작성한 상태입니다. 어느 쪽이 더 좋아 보이는지 의견 주시면 반영해서 수정하겠습니다!
